### PR TITLE
distances: add 2 helpers for consulting the distances structure

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -618,6 +618,9 @@ man3_helper_distances_DATA = \
         $(DOX_MAN_DIR)/man3/hwloc_distances_get_by_depth.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_get_by_type.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_release.3 \
+        $(DOX_MAN_DIR)/man3/hwlocality_distances_consult.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_distances_obj_index.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_distances_obj_pair_values.3 \
         $(DOX_MAN_DIR)/man3/hwlocality_distances_add.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_add_flag_e.3 \
         $(DOX_MAN_DIR)/man3/HWLOC_DISTANCES_ADD_FLAG_GROUP.3 \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -619,9 +619,9 @@ man3_helper_distances_DATA = \
         $(DOX_MAN_DIR)/man3/hwloc_distances_get_by_type.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_release.3 \
         $(DOX_MAN_DIR)/man3/hwlocality_distances_add.3 \
-        $(DOX_MAN_DIR)/man3/hwloc_distances_flag_e.3 \
-        $(DOX_MAN_DIR)/man3/HWLOC_DISTANCES_FLAG_GROUP.3 \
-        $(DOX_MAN_DIR)/man3/HWLOC_DISTANCES_FLAG_GROUP_INACCURATE.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_distances_add_flag_e.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_DISTANCES_ADD_FLAG_GROUP.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_add.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_remove.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_remove_by_depth.3 \

--- a/hwloc/distances.c
+++ b/hwloc/distances.c
@@ -267,7 +267,7 @@ int hwloc_internal_distances_add_by_index(hwloc_topology_t topology,
   /* cannot group without objects,
    * and we don't group from XML anyway since the hwloc that generated the XML should have grouped already.
    */
-  if (flags & HWLOC_DISTANCES_FLAG_GROUP) {
+  if (flags & HWLOC_DISTANCES_ADD_FLAG_GROUP) {
     errno = EINVAL;
     goto err;
   }
@@ -289,12 +289,12 @@ int hwloc_internal_distances_add(hwloc_topology_t topology,
     goto err;
   }
 
-  if (topology->grouping && (flags & HWLOC_DISTANCES_FLAG_GROUP)) {
+  if (topology->grouping && (flags & HWLOC_DISTANCES_ADD_FLAG_GROUP)) {
     float full_accuracy = 0.f;
     float *accuracies;
     unsigned nbaccuracies;
 
-    if (flags & HWLOC_DISTANCES_FLAG_GROUP_INACCURATE) {
+    if (flags & HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE) {
       accuracies = topology->grouping_accuracies;
       nbaccuracies = topology->grouping_nbaccuracies;
     } else {
@@ -333,7 +333,7 @@ int hwloc_internal_distances_add(hwloc_topology_t topology,
 #define HWLOC_DISTANCES_KIND_FROM_ALL (HWLOC_DISTANCES_KIND_FROM_OS|HWLOC_DISTANCES_KIND_FROM_USER)
 #define HWLOC_DISTANCES_KIND_MEANS_ALL (HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_MEANS_BANDWIDTH)
 #define HWLOC_DISTANCES_KIND_ALL (HWLOC_DISTANCES_KIND_FROM_ALL|HWLOC_DISTANCES_KIND_MEANS_ALL)
-#define HWLOC_DISTANCES_FLAG_ALL (HWLOC_DISTANCES_FLAG_GROUP|HWLOC_DISTANCES_FLAG_GROUP_INACCURATE)
+#define HWLOC_DISTANCES_ADD_FLAG_ALL (HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE)
 
 /* The actual function exported to the user
  */
@@ -354,7 +354,7 @@ int hwloc_distances_add(hwloc_topology_t topology,
   if ((kind & ~HWLOC_DISTANCES_KIND_ALL)
       || hwloc_weight_long(kind & HWLOC_DISTANCES_KIND_FROM_ALL) != 1
       || hwloc_weight_long(kind & HWLOC_DISTANCES_KIND_MEANS_ALL) != 1
-      || (flags & ~HWLOC_DISTANCES_FLAG_ALL)) {
+      || (flags & ~HWLOC_DISTANCES_ADD_FLAG_ALL)) {
     errno = EINVAL;
     return -1;
   }

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -3230,7 +3230,7 @@ look_sysfsnode(struct hwloc_topology *topology,
       if (distances)
 	hwloc_internal_distances_add(topology, nbnodes, nodes, distances,
 				     HWLOC_DISTANCES_KIND_FROM_OS|HWLOC_DISTANCES_KIND_MEANS_LATENCY,
-				     HWLOC_DISTANCES_FLAG_GROUP);
+				     HWLOC_DISTANCES_ADD_FLAG_GROUP);
       else
 	free(nodes);
   }

--- a/hwloc/topology-solaris.c
+++ b/hwloc/topology-solaris.c
@@ -425,7 +425,7 @@ hwloc_look_lgrp(struct hwloc_topology *topology)
       }
       hwloc_internal_distances_add(topology, curlgrp, glob_lgrps, distances,
 				   HWLOC_DISTANCES_KIND_FROM_OS|HWLOC_DISTANCES_KIND_MEANS_LATENCY,
-				   HWLOC_DISTANCES_FLAG_GROUP);
+				   HWLOC_DISTANCES_ADD_FLAG_GROUP);
     } else
 #endif /* HAVE_DECL_LGRP_LATENCY_COOKIE */
       free(glob_lgrps);

--- a/include/hwloc/distances.h
+++ b/include/hwloc/distances.h
@@ -41,7 +41,8 @@ extern "C" {
 struct hwloc_distances_s {
   unsigned nbobjs;		/**< \brief Number of objects described by the distance matrix. */
   hwloc_obj_t *objs;		/**< \brief Array of objects described by the distance matrix.
-				 * These objects are not in any particular order.
+				 * These objects are not in any particular order,
+				 * see hwloc_distances_obj_index() and hwloc_distances_obj_pair_values().
 				 */
   unsigned long kind;		/**< \brief OR'ed set of ::hwloc_distances_kind_e. */
   hwloc_uint64_t *values;	/**< \brief Matrix of distances between objects, stored as a one-dimension array.
@@ -144,6 +145,49 @@ hwloc_distances_get_by_type(hwloc_topology_t topology, hwloc_obj_type_t type,
 /** \brief Release a distance structure previously returned by hwloc_distances_get(). */
 HWLOC_DECLSPEC void
 hwloc_distances_release(hwloc_topology_t topology, struct hwloc_distances_s *distances);
+
+/** @} */
+
+
+
+/** \defgroup hwlocality_distances_consult Helpers for consulting distances structures
+ * @{
+ */
+
+/** \brief Find the index of an object in a distances structure.
+ *
+ * \return -1 if the object is not involved in this distances structure.
+ */
+static __hwloc_inline int
+hwloc_distances_obj_index(struct hwloc_distances_s *distances, hwloc_obj_t obj)
+{
+  unsigned i;
+  for(i=0; i<distances->nbobjs; i++)
+    if (distances->objs[i] == obj)
+      return (int)i;
+  return -1;
+}
+
+/** brief Find the values between two objects in a distances structure.
+ *
+ * The distance from \p obj1 to \p obj2 is stored in the value pointed by
+ * \p value1to2 and reciprocally.
+ *
+ * \return -1 if these objects are not involved in this distances structure.
+ */
+static __hwloc_inline int
+hwloc_distances_obj_pair_values(struct hwloc_distances_s *distances,
+				hwloc_obj_t obj1, hwloc_obj_t obj2,
+				hwloc_uint64_t *value1to2, hwloc_uint64_t *value2to1)
+{
+  int i1 = hwloc_distances_obj_index(distances, obj1);
+  int i2 = hwloc_distances_obj_index(distances, obj2);
+  if (i1 < 0 || i2 < 0)
+    return -1;
+  *value1to2 = distances->values[i1 * distances->nbobjs + i2];
+  *value2to1 = distances->values[i2 * distances->nbobjs + i1];
+  return 0;
+}
 
 /** @} */
 

--- a/include/hwloc/distances.h
+++ b/include/hwloc/distances.h
@@ -154,17 +154,17 @@ hwloc_distances_release(hwloc_topology_t topology, struct hwloc_distances_s *dis
  */
 
 /** \brief Flags for adding a new distances to a topology. */
-enum hwloc_distances_flag_e {
+enum hwloc_distances_add_flag_e {
   /** \brief Try to group objects based on the newly provided distance information.
    * \hideinitializer
    */
-  HWLOC_DISTANCES_FLAG_GROUP = (1UL<<0),
+  HWLOC_DISTANCES_ADD_FLAG_GROUP = (1UL<<0),
   /** \brief If grouping, consider the distance values as inaccurate and relax the
    * comparisons during the grouping algorithms. The actual accuracy may be modified
    * through the HWLOC_GROUPING_ACCURACY environment variable (see \ref envvar).
    * \hideinitializer
    */
-  HWLOC_DISTANCES_FLAG_GROUP_INACCURATE = (1UL<<1)
+  HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE = (1UL<<1)
 };
 
 /** \brief Provide a distance matrix.
@@ -177,7 +177,7 @@ enum hwloc_distances_flag_e {
  * \p kind specifies the kind of distance as a OR'ed set of ::hwloc_distances_kind_e.
  *
  * \p flags configures the behavior of the function using an optional OR'ed set of
- * ::hwloc_distances_flag_e.
+ * ::hwloc_distances_add_flag_e.
  *
  * Objects must be of the same type. They cannot be of type Group.
  */

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -376,6 +376,8 @@ extern "C" {
 #define hwloc_distances_get_by_depth HWLOC_NAME(distances_get_by_depth)
 #define hwloc_distances_get_by_type HWLOC_NAME(distances_get_by_type)
 #define hwloc_distances_release HWLOC_NAME(distances_release)
+#define hwloc_distances_obj_index HWLOC_NAME(distances_obj_index)
+#define hwloc_distances_obj_pair_values HWLOC_NAME(distances_pair_values)
 
 #define hwloc_distances_add_flag_e HWLOC_NAME(distances_add_flag_e)
 #define HWLOC_DISTANCES_ADD_FLAG_GROUP HWLOC_NAME_CAPS(DISTANCES_ADD_FLAG_GROUP)

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -377,9 +377,9 @@ extern "C" {
 #define hwloc_distances_get_by_type HWLOC_NAME(distances_get_by_type)
 #define hwloc_distances_release HWLOC_NAME(distances_release)
 
-#define hwloc_distances_flag_e HWLOC_NAME(distances_flag_e)
-#define HWLOC_DISTANCES_FLAG_GROUP HWLOC_NAME_CAPS(DISTANCES_FLAG_GROUP)
-#define HWLOC_DISTANCES_FLAG_GROUP_INACCURATE HWLOC_NAME_CAPS(DISTANCES_FLAG_GROUP_INACCURATE)
+#define hwloc_distances_add_flag_e HWLOC_NAME(distances_add_flag_e)
+#define HWLOC_DISTANCES_ADD_FLAG_GROUP HWLOC_NAME_CAPS(DISTANCES_ADD_FLAG_GROUP)
+#define HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE HWLOC_NAME_CAPS(DISTANCES_ADD_FLAG_GROUP_INACCURATE)
 
 #define hwloc_distances_add HWLOC_NAME(distances_add)
 #define hwloc_distances_remove HWLOC_NAME(distances_remove)

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -131,6 +131,7 @@ struct hwloc_topology {
 		       */
     unsigned long kind;
 
+    /* objects are currently stored in physical_index order */
     hwloc_obj_t *objs; /* array of objects */
     int objs_are_valid; /* set to 1 if the array objs is still valid, 0 if needs refresh */
 

--- a/tests/hwloc/hwloc_distances.c
+++ b/tests/hwloc/hwloc_distances.c
@@ -64,7 +64,7 @@ int main(void)
   hwloc_topology_t topology;
   struct hwloc_distances_s *distances[2];
   hwloc_obj_t objs[16];
-  uint64_t values[16*16];
+  uint64_t values[16*16], value1, value2;
   unsigned topodepth;
   unsigned i, j, k, nr;
   int err;
@@ -115,6 +115,20 @@ int main(void)
   assert(distances[0]->objs);
   assert(distances[0]->values);
   assert(distances[0]->kind == (HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER));
+  /* check helpers */
+  assert(hwloc_distances_obj_index(distances[0], hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2)) == 2);
+  assert(hwloc_distances_obj_pair_values(distances[0],
+					 hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 1),
+					 hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2),
+					 &value1, &value2) == 0);
+  assert(value1 == values[1*4+2]);
+  assert(value2 == values[2*4+1]);
+  /* check helpers on errors */
+  assert(hwloc_distances_obj_index(distances[0], hwloc_get_obj_by_type(topology, HWLOC_OBJ_PU, 0)) == -1);
+  assert(hwloc_distances_obj_pair_values(distances[0],
+					 hwloc_get_obj_by_type(topology, HWLOC_OBJ_PU, 1),
+					 hwloc_get_obj_by_type(topology, HWLOC_OBJ_PU, 2),
+					 &value1, &value2) == -1);
   /* check that some random values are ok */
   assert(distances[0]->values[0] == 1); /* diagonal */
   assert(distances[0]->values[4] == 4); /* same group */

--- a/tests/hwloc/hwloc_distances.c
+++ b/tests/hwloc/hwloc_distances.c
@@ -94,7 +94,7 @@ int main(void)
     values[i+4*i] = 1;
   err = hwloc_distances_add(topology, 4, objs, values,
 			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_FLAG_GROUP);
+			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   topodepth = hwloc_topology_get_depth(topology);
@@ -143,7 +143,7 @@ int main(void)
     values[i+16*i] = 1;
   err = hwloc_distances_add(topology, 16, objs, values,
 			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_FLAG_GROUP);
+			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   topodepth = hwloc_topology_get_depth(topology);
@@ -185,7 +185,7 @@ int main(void)
     values[i+4*i] = 7;
   err = hwloc_distances_add(topology, 4, objs, values,
 			    HWLOC_DISTANCES_KIND_MEANS_BANDWIDTH|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_FLAG_GROUP);
+			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   topodepth = hwloc_topology_get_depth(topology);

--- a/tests/hwloc/hwloc_groups.c
+++ b/tests/hwloc/hwloc_groups.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2011-2016 Inria.  All rights reserved.
+ * Copyright © 2011-2017 Inria.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -35,7 +35,7 @@ int main(void)
   values[6] = 4; values[7] = 2; values[8] = 1;
   err = hwloc_distances_add(topology, 3, objs, values,
 			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_FLAG_GROUP);
+			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
   /* 2 groups at depth 1 */
   depth = hwloc_get_type_depth(topology, HWLOC_OBJ_GROUP);
@@ -72,7 +72,7 @@ int main(void)
   values[20] = 4; values[21] = 4; values[22] = 4; values[23] = 2; values[24] = 1;
   err = hwloc_distances_add(topology, 5, objs, values,
 			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_FLAG_GROUP);
+			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
   /* 1 node at depth 1 */
   depth = hwloc_get_type_depth(topology, HWLOC_OBJ_NUMANODE);
@@ -143,7 +143,7 @@ int main(void)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
   assert(!hwloc_distances_add(topology, 16, objs, values,
 			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_FLAG_GROUP));
+			      HWLOC_DISTANCES_ADD_FLAG_GROUP));
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 6);
   width = hwloc_get_nbobjs_by_depth(topology, 0);
@@ -169,7 +169,7 @@ int main(void)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
   assert(!hwloc_distances_add(topology, 16, objs, values,
 			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_FLAG_GROUP|HWLOC_DISTANCES_FLAG_GROUP_INACCURATE));
+			      HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE));
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 6);
   hwloc_topology_destroy(topology);
@@ -182,7 +182,7 @@ int main(void)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
   assert(!hwloc_distances_add(topology, 16, objs, values,
 			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_FLAG_GROUP|HWLOC_DISTANCES_FLAG_GROUP_INACCURATE));
+			      HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE));
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 6);
   hwloc_topology_destroy(topology);
@@ -194,7 +194,7 @@ int main(void)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
   assert(!hwloc_distances_add(topology, 16, objs, values,
 			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_FLAG_GROUP /* no inaccurate flag, cannot group */));
+			      HWLOC_DISTANCES_ADD_FLAG_GROUP /* no inaccurate flag, cannot group */));
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 4);
   hwloc_topology_destroy(topology);
@@ -207,7 +207,7 @@ int main(void)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
   assert(!hwloc_distances_add(topology, 16, objs, values,
 			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_FLAG_GROUP|HWLOC_DISTANCES_FLAG_GROUP_INACCURATE));
+			      HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE));
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 4);
   hwloc_topology_destroy(topology);
@@ -220,7 +220,7 @@ int main(void)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
   assert(!hwloc_distances_add(topology, 16, objs, values,
 			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_FLAG_GROUP|HWLOC_DISTANCES_FLAG_GROUP_INACCURATE));
+			      HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE));
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 4);
   hwloc_topology_destroy(topology);
@@ -252,7 +252,7 @@ int main(void)
   }
   assert(!hwloc_distances_add(topology, 8, objs, values,
 			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_FLAG_GROUP));
+			      HWLOC_DISTANCES_ADD_FLAG_GROUP));
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 4);
   /* group 4cores as 2*2 */
@@ -268,7 +268,7 @@ int main(void)
   }
   assert(!hwloc_distances_add(topology, 8, objs, values,
 			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_FLAG_GROUP));
+			      HWLOC_DISTANCES_ADD_FLAG_GROUP));
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 5);
   width = hwloc_get_nbobjs_by_depth(topology, 0);
@@ -294,7 +294,7 @@ int main(void)
   }
   assert(!hwloc_distances_add(topology, 32, objs, values,
 			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_FLAG_GROUP));
+			      HWLOC_DISTANCES_ADD_FLAG_GROUP));
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 6);
   width = hwloc_get_nbobjs_by_depth(topology, 0);

--- a/tests/hwloc/hwloc_topology_dup.c
+++ b/tests/hwloc/hwloc_topology_dup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2011-2016 Inria.  All rights reserved.
+ * Copyright © 2011-2017 Inria.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -32,7 +32,7 @@ int main(void)
   }
   err = hwloc_distances_add(oldtopology, 3, nodes, node_distances,
 			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_FLAG_GROUP);
+			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   for(i=0; i<6; i++) {
@@ -42,7 +42,7 @@ int main(void)
   }
   err = hwloc_distances_add(oldtopology, 6, cores, core_distances,
 			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_FLAG_GROUP);
+			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   printf("duplicating\n");

--- a/tests/hwloc/hwloc_topology_restrict.c
+++ b/tests/hwloc/hwloc_topology_restrict.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2011-2016 Inria.  All rights reserved.
+ * Copyright © 2011-2017 Inria.  All rights reserved.
  * Copyright © 2011 Université Bordeaux.  All rights reserved.
  * See COPYING in top-level directory.
  */
@@ -118,7 +118,7 @@ int main(void)
   }
   err = hwloc_distances_add(topology, 3, nodes, node_distances,
 			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_FLAG_GROUP);
+			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   for(i=0; i<6; i++) {
@@ -128,7 +128,7 @@ int main(void)
   }
   err = hwloc_distances_add(topology, 6, cores, core_distances,
 			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_FLAG_GROUP);
+			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   /* entire topology */


### PR DESCRIPTION
Objects are not in any specific order in v2 distances matrix,
because matrices can cover only part of the machines.
So provide functions to extract matrix values from object pointers.

Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>